### PR TITLE
Restore Dollar Amount Edit functionality

### DIFF
--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -116,6 +116,7 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 				<div class="input-group-addon">$</div>
 				<!-- Maximum length of 8 includes cents (.xx) -->
 				<input class="form-control" id="otherAmount" placeholder="Other Amount" maxlength="8" data-max="99999" value="100" type="text">
+				<span id="errorOtherAmount" class="error"></span>
 			</div>
 			<input name="inpAmount" id="inpAmount" class="value" data-token="amount" value="100" type="hidden">
 		</div>
@@ -161,6 +162,8 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 		wp_enqueue_script( 'wsuf_fundselector_utils', plugins_url( '/wsuwp-shortcode-fundselector-utils.js', __FILE__ ), array( 'jquery' ), '1.0', true );
 
 		wp_enqueue_script( 'wsuf_fundselector', plugins_url( '/wsuwp-shortcode-fundselector.js', __FILE__ ), array( 'jquery', 'jquery-ui-core', 'jquery-ui-autocomplete', 'jquery-ui-button', 'underscore' ), '1.0', true );
+
+		wp_enqueue_script( 'wsuf_fundselector_jquery_editable', plugins_url( '/jquery.editable.min.js', __FILE__ ), array( 'jquery' ), null, true );
 
 		wp_localize_script( 'wsuf_fundselector', 'wpData', array(
 			'request_url_base' => esc_url( rest_url( '/wp/v2/' ) ),

--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -6,11 +6,36 @@ window.wsuwpUtils = window.wsuwpUtils || {};
     window.wsuwpUtils = {
 
 		addListItem: function ( $list, name, designationId, amount  ) {
-		    var html = '<li class="list-group-item" data-designation_id="' + designationId + '" data-amount="' + amount + '"><span class="left">$' + amount +  '</span><span class="right">' + _.escape(name) + '</span><span class="close"><a href="#"></a></span></li>';
-			
-			if(!this.isDuplicateDesignation(designationId, $list))
+		    var html = '<li class="list-group-item" data-designation_id="' + designationId + '" data-amount="' + amount + '"></li>';
+			var html = '<li class="list-group-item" data-designation_id="' + designationId + '" data-amount="' + amount + '">';
+			html += '<span class="right">' + _.escape(name) + '</span>'
+			html += ' $<span id="edit' + designationId + '" class="editable left">' + amount +  '</span>';
+			html += '<input id="' + designationId +'" class="edit" type="button" value="Edit Amount"></input>';
+			html += '<span class="close remove"><a href="#"></a></span>'
+			html += '<span id="error' + designationId + '" class="error"></span></li>';
+
+			if(!wsuwpUtils.isDuplicateDesignation(designationId, $list))
 			{
 				$list.append(html);
+
+				// jQuery Editable
+				var $editButton = jQuery("input#" + designationId);
+				
+				$editButton.click(function (e) { e.preventDefault(); } );
+				
+				var option = {trigger : $editButton, action : "click"};
+				jQuery("span#edit" + designationId).editable(option, function(e){
+					
+					if( !wsuwpUtils.validateAmount(e.value) ){
+						// Revert back to the original value
+						e.target.html(e.old_value);
+						jQuery("#error" + designationId).text("Amount must be between $3 and $100,000. Amount was reset.");
+					}
+					else{
+						e.target.parent().attr("data-amount", e.value);
+						jQuery("#error" + designationId).text("");
+					}
+				});
 			}
 		},
 
@@ -27,6 +52,18 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 			});
 
 			 return duplicate;
+		},
+
+		validateAmount(intendedAmount)
+		{
+			var validMoneyAmount = false;
+
+			var inputAmount = parseFloat(intendedAmount);
+			if(inputAmount && _.isNumber(inputAmount) && inputAmount > 0 && intendedAmount.match(/^\d{1,5}(?:\.\d{0,2})?$/)){
+				validMoneyAmount = true;
+			}
+
+			return validMoneyAmount;
 		},
 
 		getDesignationList: function ($listElement)

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -125,19 +125,15 @@ jQuery(document).ready(function($) {
 
 		$("#fundSearch").val("");
 		$('.fund-selection').prop('selectedIndex', 0);
-
-		continueAction();
 	});
 
 	// Remove Fund Button Click Event
 	// (Using body to defer binding until element has been created)
-	$('body').on('click', '#selectedFunds li a', function (event) {
+	$('body').on('click', '#selectedFunds li span.remove a', function (event) {
 		event.preventDefault();
 		
 		$(this).parent().parent().remove();
 
-		//continueAction();
-		
 		// If the Fund list is empty, disable the Continue Button
 		if($("#selectedFunds").find("li").length === 0)
 		{
@@ -156,14 +152,21 @@ jQuery(document).ready(function($) {
 
 		$(".amount-selection").removeClass("selected");
 		$this.addClass("selected");
+
+		jQuery("#errorOtherAmount").text("");
     });
 
 	// Other Amount text field Change Event
 	$("#otherAmount").on('input propertychange paste', function () {
-		var inputAmount = parseFloat($(this).val());
-		if(inputAmount && _.isNumber(inputAmount) && inputAmount > 0)
+		var inputAmount = $(this).val();
+		if(wsuwpUtils.validateAmount(inputAmount))
 		{
 			$("#inpAmount").val(inputAmount);
+			jQuery("#errorOtherAmount").text("");
+		}
+		else
+		{
+			jQuery("#errorOtherAmount").text("Amount should be between $3 and $100,000.");
 		}		
 	});
 

--- a/style-guide/index.html
+++ b/style-guide/index.html
@@ -26,7 +26,7 @@
     <link rel='stylesheet' id='spine-theme-print-css'  href='https://wp.wsu.edu/wp-content/themes/spine/css/print.css?ver=0.27.6-1.5.4-39525' type='text/css' media='print' />
     <link rel='stylesheet' id='open-sans-css'  href='https://fonts.googleapis.com/css?family=Open+Sans%3A400%2C400italic%2C700%2C700italic&#038;subset=latin%2Clatin-ext&#038;ver=4.7' type='text/css' media='all' />
 
-    <link rel='stylesheet' id='wsuf_fundselector-css'  href='../includes/wsuwp-plugin-idonate.css' type='text/css' media='all' />
+    <link rel='stylesheet' id='wsuf_fundselector-css'  href='../css/wsuwp-plugin-idonate.css' type='text/css' media='all' />
 
     <script type='text/javascript' src='https://wp.wsu.edu/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
     <script type='text/javascript' src='https://wp.wsu.edu/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
@@ -89,36 +89,34 @@
                         <div class="article-body">
 
                             <div id="fundSelectionForm">
-                                <div id="majorcategory" class="" role="group" aria-label="Category Selection Group">
+                                <div id="majorcategory" class="wrapper" role="group" aria-label="Category Selection Group">
                                     <a class="active" role="button" data-tab="prioritiesTab" href="#" >Priorities</a>
                                     <a class="" role="button" data-tab="subcategoryTab" data-category="idonate_programs" href="#">Programs</a>
                                     <a class="" role="button" data-tab="subcategoryTab" data-category="idonate_colleges" href="#">Colleges</a>
                                     <a class="" role="button" data-tab="subcategoryTab" data-category="idonate_campuses" href="#">Campuses</a>
-                                </div>
-                                <div id="prioritiesTab" class="categoryTab">
+									<span><a class="search" role="button" href="#"></a></span>
+								</div>
+                                <div id="prioritiesTab" class="categoryTab wrapper">
                                     <label for="priorities">Choose one of the university's greatest needs</label>
-                                    <select name="priorities" id="priorities" class="form-control fund-selection"><option disabled selected value> -- Select a Fund -- </option><option value="667abedd-c2d1-47e4-9851-ceb8acfcc39a">Crimson Opportunity Scholarship Fund (General Scholarships)</option><option value="ffb10db4-4c30-4e0b-84c5-39ecabb31bad">Dr. Elson S. Floyd Medical Education Founder&#039;s Fund</option><option value="1b356929-5b78-44b5-bda4-3255c7769e24">Elson S. Floyd College of Medicine Student Scholarship Fund</option><option value="76602a05-de33-4bf8-a7d9-7683b97a601a">North Puget Sound Chancellor&#039;s Excellence Fund</option><option value="12dc5acc-07ea-4ed3-9c92-4b9ebe7c951c">President&#039;s Excellence Fund</option><option value="acda72ce-e4b2-4b41-8922-5d9320b44b05">WSU Spokane Chancellor&#039;s Excellence Fund</option><option value="753c564f-ba71-44b4-8766-c1aa81ef36b8">WSU Tri-Cities Chancellor&#039;s Excellence Fund</option><option value="d92d0b02-8d2f-4b4b-a908-8505b916819f">WSU Vancouver Annual Fund</option></select>
+                                    <select name="priorities" id="priorities" class="form-control fund-selection"><option disabled selected value> SELECT A FUND </option><option value="667abedd-c2d1-47e4-9851-ceb8acfcc39a">Crimson Opportunity Scholarship Fund (General Scholarships)</option><option value="ffb10db4-4c30-4e0b-84c5-39ecabb31bad">Dr. Elson S. Floyd Medical Education Founder&#039;s Fund</option><option value="1b356929-5b78-44b5-bda4-3255c7769e24">Elson S. Floyd College of Medicine Student Scholarship Fund</option><option value="76602a05-de33-4bf8-a7d9-7683b97a601a">North Puget Sound Chancellor&#039;s Excellence Fund</option><option value="12dc5acc-07ea-4ed3-9c92-4b9ebe7c951c">President&#039;s Excellence Fund</option><option value="acda72ce-e4b2-4b41-8922-5d9320b44b05">WSU Spokane Chancellor&#039;s Excellence Fund</option><option value="753c564f-ba71-44b4-8766-c1aa81ef36b8">WSU Tri-Cities Chancellor&#039;s Excellence Fund</option><option value="d92d0b02-8d2f-4b4b-a908-8505b916819f">WSU Vancouver Annual Fund</option></select>
                                 </div>
                                 <div id="subcategoryTab" class="categoryTab hidden">
                                     <label for="subcategories">Choose a category</label>
                                     <select name="subcategories" id="subcategories" class="form-control">
-                                        <option disabled selected value> -- Select a Category -- </option>
+                                        <option disabled selected value> SELECT A CATEGORY </option>
                                     </select>
                                     <label for="funds">Choose a fund</label>
                                     <select name="funds" id="funds" class="form-control fund-selection" disabled>
-                                        <option disabled selected value> -- Select a Fund -- </option>
+                                        <option disabled selected value> SELECT A FUND </option>
                                     </select></div>
-                                <div class="search-separator">
-                                    OR
-                                </div>
 
-                                <div class="form-group has-feedback">
+                                <div class="form-group has-feedback wrapper search hidden">
                                     <label for="fundSearch">Search for any Fund: </label>
                                     <input id="fundSearch" type="search" class="form-control" placeholder="Search for a fund..." >
                                     <span class="glyphicon glyphicon-search form-control-feedback" aria-hidden="true"></span>
                                 </div>
 
-                                <div class="" role="group">
+                                <div class="amountwrapper wrapper" role="group">
                                     <button type="button" class="amount-selection btn btn-default selected" data-amount="25" >$25</button>
                                     <button type="button" class="amount-selection btn btn-default" data-amount="50">$50</button>
                                     <button type="button" class="amount-selection btn btn-default" data-amount="100">$100</button>
@@ -126,19 +124,21 @@
                                     <div class="input-group">
                                         <div class="input-group-addon">$</div>
                                         <!-- Maximum length of 8 includes cents (.xx) -->
-                                        <input type="text" class="form-control" id="otherAmount" placeholder="Other Amount" maxlength="8" data-max="99999">
+                                        <input type="text" class="form-control" id="otherAmount" placeholder="Other Amount" maxlength="8" data-max="99999" value="100">
                                         <span id="errorOtherAmount" class="error"></span>
                                     </div>
-                                    <input name="inpAmount" id="inpAmount" class="value" data-token="amount" value="25" type="hidden">
+                                    <input name="inpAmount" id="inpAmount" class="value" data-token="amount" value="100" type="hidden">
                                 </div>
 
 								<input name="inpDesignationId" id="inpDesignationId" type="hidden">
 								<input name="inpFundName" id="inpFundName" type="hidden">
 								<button id="addFundButton" type="button">Add Fund</button>
 
-                                <ul id="selectedFunds" class="list-group">
+                                <ul id="selectedFunds" class="list-group wrapper">
                                 </ul>
-                                <button type="button" id="continueButton" class="btn btn-default" disabled>Continue</button><h2 id="embedLoadingMessage" style="display: none;">Loading Payment Process</h2><div id="iDonateEmbed" data-idonate-embed="507485b9-ac27-42d3-a0d4-db5b1d5d7f6c" data-defer></div></div>
+                                <p class="txtright continuebutton"><a class="btnlhtgry" id="continueButton">Continue</a></p>
+								
+								<h2 id="embedLoadingMessage" style="display: none;">Loading Payment Process</h2><div id="iDonateEmbed" data-idonate-embed="507485b9-ac27-42d3-a0d4-db5b1d5d7f6c" data-defer></div></div>
 
                         </div>
 


### PR DESCRIPTION
The Edit Dollar Amount functionality got overwritten by the style changes, so I merged them in with latest changes. 

Dollar Amount Edit Changes:
- Moved the dollar amount after the fund name in the fund list and set it as editable
- Added an Edit Amount button after the dollar amount
- Added two new fields for dollar amount validation errors

Additional Changes
- Fixed the selector for the Remove button
- Took the Continue action off of the Add Fund button
- Updated the style guide to reflect the current styling and HTML changes.