### PR TITLE
Change Edit link to unused element instead of top of page - Issue #71

### DIFF
--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -9,7 +9,7 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 			var html = '<li class="list-group-item ' + (scholarship ? "fund-scholarship": "") + '" data-designation_id="' + designationId + '" data-amount="' + amount + '">';
 			html += '<span class="right">' + _.escape(name) + '</span>'
 			html += '<span class="center">$</span><span id="edit' + designationId + '" class="editable left">' + amount +  '</span>';
-			html += '<span class="edit"><a href="#" id="' + designationId +'" class="edit">EDIT</a></span>';
+			html += '<span class="edit"><a href="#!" id="' + designationId +'" class="edit">EDIT</a></span>';
 			html += '<span class="close remove"><a href="#"></a></span>'
 			html += '<span id="error' + designationId + '" class="error"></span></li>';
 			


### PR DESCRIPTION
I updated the edit link to use an unused element instead of the top of the page to prevent the scroll to top issue in #71.