### PR TITLE
Update total amount when scholarship is unchecked - Issue #89

### DIFF
--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -204,6 +204,8 @@ jQuery(document).ready(function($) {
 			// the checkbox is now no longer checked
 			$("#selectedFunds > li.fund-scholarship").remove();
 
+			wsuwpUtils.updateTotalAmountText();
+
 			// If the Fund list is empty, disable the Continue Button
 			if ($("#selectedFunds").find("li").length === 0) {
 				wsuwpUtils.disableButton($("#continueButton"));


### PR DESCRIPTION
The total amount didn't update when the scholarship checkbox was unchecked and the fund was removed.

This fix for #89 updates the total amount when fund is removed by unchecking the scholarship box.