### PR TITLE
Add fund via query parameter (Issue #96)

### DIFF
--- a/includes/class-wsuwp-plugin-idonate-restapi.php
+++ b/includes/class-wsuwp-plugin-idonate-restapi.php
@@ -25,6 +25,10 @@ class WSUWP_Plugin_iDonate_Custom_REST_API {
 		add_action( 'rest_api_init', array( $this, 'wsuf_fundselector_register_designation_id' ) );
 		add_action( 'rest_api_init', array( $this, 'wsuf_fundselector_register_endpoint_get_funds' ) );
 
+		/** Loads the fundselector shortcode class file. */
+		require_once( dirname( __FILE__ ) . '/class-wsuwp-shortcode-fundselector.php' );
+
+		$this->fundselector_shortcode = new WSUWP_Plugin_iDonate_ShortCode_Fund_Selector();
 	}
 
 	/**
@@ -82,11 +86,6 @@ class WSUWP_Plugin_iDonate_Custom_REST_API {
 		$category = $data['category'];
 		$subcategory = $data['subcategory'];
 
-		/** Loads the fundselector shortcode class file. */
-		require_once( dirname( __FILE__ ) . '/class-wsuwp-shortcode-fundselector.php' );
-
-		$fundselector_shortcode = new WSUWP_Plugin_iDonate_ShortCode_Fund_Selector();
-
-		return $fundselector_shortcode->wsuf_fundselector_funds_get_funds( $category, $subcategory );
+		return $this->fundselector_shortcode->wsuf_fundselector_funds_get_funds( $category, $subcategory );
 	}
 }

--- a/includes/class-wsuwp-plugin-idonate-restapi.php
+++ b/includes/class-wsuwp-plugin-idonate-restapi.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * plugin class file for the custom fundselector REST API additions
+ *
+ * Defines the functions necessary to register our custom REST API methods with
+ * WordPress.
+ *
+ * @link       https://github.com/washingtonstateuniversity/WSUWP-Plugin-iDonate
+ * @since      0.0.17
+ *
+ * @package    WSUWP_Plugin_iDonate_Custom_REST_API
+ * @author     Blair Lierman
+ */
+class WSUWP_Plugin_iDonate_Custom_REST_API {
+
+	/**
+	 * Initializes the plugin by registering the hooks necessary
+	 * for creating our custom post type within WordPress.
+	 *
+	 * @since    0.0.17
+	 */
+	public function init() {
+
+		add_action( 'rest_api_init', array( $this, 'wsuf_fundselector_register_designation_id' ) );
+		add_action( 'rest_api_init', array( $this, 'wsuf_fundselector_register_endpoint_get_funds' ) );
+
+	}
+
+	/**
+	* Add the designation ID to the Fund response
+	**/
+	function wsuf_fundselector_register_designation_id() {
+		register_rest_field( 'idonate_fund',
+			'designationId',
+			array(
+				'get_callback'    => array( $this, 'wsuf_fundselector_get_post_meta' ),
+				'update_callback' => null,
+				'schema'          => null,
+			)
+		);
+	}
+
+	/**
+	* Get the value for the specified field_name argument
+	*
+	* @param array $object Details of current post.
+	* @param string $field_name Name of field.
+	* @param WP_REST_Request $request Current request
+	*
+	* @return mixed
+	*/
+	function wsuf_fundselector_get_post_meta( $object, $field_name, $request ) {
+		return get_post_meta( $object['id'], $field_name, true );
+	}
+
+	/**
+	* Add a new custom REST endpoint to get funds for a specific taxonomy and category by slug
+	*
+	* @since 0.0.5
+	**/
+	function wsuf_fundselector_register_endpoint_get_funds() {
+		register_rest_route( 'idonate_fundselector/v1', '/funds/(?P<category>.*?)/(?P<subcategory>.*)',
+			array(
+				'methods' => 'GET',
+				'callback' => array( $this, 'wsuf_fundselector_funds_get_funds_rest' ),
+			)
+		);
+	}
+
+	/**
+	* Get a list of funds for a specific taxonomy and category via the REST API
+	*
+	* @param WP_Rest_Request $data data from the REST request
+	*
+	* @return array $return_array (from wsuf_fundselector_funds_get_funds)
+	*
+	* @since 0.0.5
+	*/
+	function wsuf_fundselector_funds_get_funds_rest( $data ) {
+
+		$category = $data['category'];
+		$subcategory = $data['subcategory'];
+
+		/** Loads the fundselector shortcode class file. */
+		require_once( dirname( __FILE__ ) . '/class-wsuwp-shortcode-fundselector.php' );
+
+		$fundselector_shortcode = new WSUWP_Plugin_iDonate_ShortCode_Fund_Selector();
+
+		return $fundselector_shortcode->wsuf_fundselector_funds_get_funds( $category, $subcategory );
+	}
+}

--- a/includes/class-wsuwp-plugin-idonate-restapi.php
+++ b/includes/class-wsuwp-plugin-idonate-restapi.php
@@ -24,6 +24,7 @@ class WSUWP_Plugin_iDonate_Custom_REST_API {
 
 		add_action( 'rest_api_init', array( $this, 'wsuf_fundselector_register_designation_id' ) );
 		add_action( 'rest_api_init', array( $this, 'wsuf_fundselector_register_endpoint_get_funds' ) );
+		add_action( 'rest_api_init', array( $this, 'wsuf_fundselector_register_endpoint_get_fund_by_des_id' ) );
 
 		/** Loads the fundselector shortcode class file. */
 		require_once( dirname( __FILE__ ) . '/class-wsuwp-shortcode-fundselector.php' );
@@ -87,5 +88,35 @@ class WSUWP_Plugin_iDonate_Custom_REST_API {
 		$subcategory = $data['subcategory'];
 
 		return $this->fundselector_shortcode->wsuf_fundselector_funds_get_funds( $category, $subcategory );
+	}
+
+	/**
+	* Add a new custom REST endpoint to get a fund name for a specific designation ID by slug
+	*
+	* @since 0.0.17
+	**/
+	function wsuf_fundselector_register_endpoint_get_fund_by_des_id() {
+		register_rest_route( 'idonate_fundselector/v1', '/fund/(?P<designationId>.*?)',
+			array(
+				'methods' => 'GET',
+				'callback' => array( $this, 'wsuf_fundselector_funds_get_fund_by_des_id_rest' ),
+			)
+		);
+	}
+
+	/**
+	* Gets a fund for a specific designation ID passed via the REST API
+	*
+	* @param WP_Rest_Request $data data from the REST request
+	*
+	* @return array $return_array (from wsuf_fundselector_funds_get_funds)
+	*
+	* @since 0.0.17
+	*/
+	function wsuf_fundselector_funds_get_fund_by_des_id_rest( $data ) {
+
+		$designation_id = $data['designationId'];
+
+		return $this->fundselector_shortcode->wsuf_fundselector_funds_get_fund_name( $designation_id );
 	}
 }

--- a/includes/class-wsuwp-plugin-idonate.php
+++ b/includes/class-wsuwp-plugin-idonate.php
@@ -31,6 +31,7 @@ class WSUWP_Plugin_iDonate {
 		self::$instance->custom_posttypes_run();
 		self::$instance->custom_taxonomies_run();
 		self::$instance->fundselector_shortcode_run();
+		self::$instance->fundselector_custom_rest_api_run();
 	}
 
 	/**
@@ -78,6 +79,22 @@ class WSUWP_Plugin_iDonate {
 
 		$fundselector_shortcode = new WSUWP_Plugin_iDonate_ShortCode_Fund_Selector();
 		$fundselector_shortcode->init();
+
+	}
+
+	/**
+	* Creates an instance of the WSUWP_Plugin_iDonate_Custom_REST_API class
+	* and calls its initialization method.
+	*
+	* @since    0.0.17
+	*/
+	private function fundselector_custom_rest_api_run() {
+
+		/** Loads the fundselector shortcode class file. */
+		require_once( dirname( __FILE__ ) . '/class-wsuwp-plugin-idonate-restapi.php' );
+
+		$fundselector_custom_rest_api = new WSUWP_Plugin_iDonate_Custom_REST_API();
+		$fundselector_custom_rest_api->init();
 
 	}
 }

--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -24,8 +24,6 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 
 		add_shortcode( 'idonate_fundselector', array( $this, 'fundselector_create_shortcode' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'wsuf_fundselector_enqueue_scripts' ), 99 );
-		add_action( 'rest_api_init', array( $this, 'wsuf_fundselector_register_designation_id' ) );
-		add_action( 'rest_api_init', array( $this, 'wsuf_fundselector_register_endpoint_get_funds' ) );
 	}
 
 	// [idonate_fundselector embed="iDonate-embed-guid" server="production/staging"]
@@ -271,64 +269,6 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 		wp_enqueue_script( 'wsuf_fundselector_jquery_editable', plugins_url( '/jquery.editable.min.js', __FILE__ ), array( 'jquery' ), null, true );
 
 		wp_enqueue_style( 'wsuf_fundselector', plugins_url( 'css/wsuwp-plugin-idonate.css', dirname( __FILE__ ) ), array( 'spine-theme' ), null );
-	}
-
-	/**
-	* Add the designation ID to the Fund response
-	**/
-	function wsuf_fundselector_register_designation_id() {
-		register_rest_field( 'idonate_fund',
-			'designationId',
-			array(
-				'get_callback'    => array( $this, 'wsuf_fundselector_get_post_meta' ),
-				'update_callback' => null,
-				'schema'          => null,
-			)
-		);
-	}
-
-	/**
-	* Get the value for the specified field_name argument
-	*
-	* @param array $object Details of current post.
-	* @param string $field_name Name of field.
-	* @param WP_REST_Request $request Current request
-	*
-	* @return mixed
-	*/
-	function wsuf_fundselector_get_post_meta( $object, $field_name, $request ) {
-		return get_post_meta( $object['id'], $field_name, true );
-	}
-
-	/**
-	* Add a new custom REST endpoint to get funds for a specific taxonomy and category by slug
-	*
-	* @since 0.0.5
-	**/
-	function wsuf_fundselector_register_endpoint_get_funds() {
-		register_rest_route( 'idonate_fundselector/v1', '/funds/(?P<category>.*?)/(?P<subcategory>.*)',
-			array(
-				'methods' => 'GET',
-				'callback' => array( $this, 'wsuf_fundselector_funds_get_funds_rest' ),
-			)
-		);
-	}
-
-	/**
-	* Get a list of funds for a specific taxonomy and category via the REST API
-	*
-	* @param WP_Rest_Request $data data from the REST request
-	*
-	* @return array $return_array (from wsuf_fundselector_funds_get_funds)
-	*
-	* @since 0.0.5
-	*/
-	function wsuf_fundselector_funds_get_funds_rest( $data ) {
-
-		$category = $data['category']; // 'idonate_priorities';
-		$subcategory = $data['subcategory'];
-
-		return $this->wsuf_fundselector_funds_get_funds( $category, $subcategory );
 	}
 
 	/**

--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -51,11 +51,14 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 		$args['unit_title'] = sanitize_text_field( $args['unit_title'] );
 		$args['unit_description'] = esc_html( $args['unit_description'] );
 
+		$des_id_query_param = ! empty( $_GET['fund'] ) ? sanitize_key( $_GET['fund'] ) : null;
+
 		wp_localize_script( 'wsuf_fundselector', 'wpData', array(
 			'request_url_base' => esc_url( $args['rest_url'] . 'wp/v2/' ),
 			'plugin_url_base' => esc_url( $args['rest_url'] . 'idonate_fundselector/v1/' ),
 			'unit_taxonomy' => $args['unit_taxonomy'],
 			'unit_category' => $args['unit_category'],
+			'unit_designation' => $des_id_query_param,
 		));
 
 		$return_string = '<div id="fundSelectionForm"><div id="firstform">';

--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -370,4 +370,39 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 
 		return $return_fund;
 	}
+
+	/**
+	* Get a list of all funds stored in the wsuf fundselector funds table
+	*
+	* @return array $return_array
+	*
+	* @since 0.0.17
+	*/
+	function wsuf_fundselector_funds_get_fund_name( $des_id ) {
+		$fund_list = get_posts(array(
+			'post_type'   => 'idonate_fund',
+			'post_status' => 'any',
+			'posts_per_page' => -1, // Get all posts
+			'meta_query' => array(
+					array(
+						'key' => 'designationId',
+						'value' => $des_id,
+						'compare' => '=',
+					),
+			),
+		));
+
+		$return_array = array();
+
+		//loop over each post
+		foreach ( $fund_list as $p ) {
+			//get the meta you need form each post
+			$des_id = get_post_meta( $p->ID, 'designationId' , true );
+			$post_title = $p->post_title;
+			//do whatever you want with it
+			$return_array[] = array( 'fund_name' => $post_title, 'designation_id' => $des_id );
+		}
+
+		return $return_array;
+	}
 }

--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -189,8 +189,19 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 		{
 			var designations = wsuwpUtils.getDesignationList(jQuery("#selectedFunds"));
 			jQuery("#totalAmount").text(wsuwpUtils.getDonationTotal(designations).toFixed(2));
-		}
+		},
 
+		/**
+		 * Selects a fund in a dropdown select list and shows the amount zone
+		 */
+		selectFundInDropdown: function($fund, designationId)
+		{
+			$fund.prop("selected", true);
+			var fundName = $fund.text();
+			jQuery("#inpDesignationId").text(designationId);
+			jQuery("#inpFundName").text(fundName);
+			showAmountZone();
+		}
 
 	}
 

--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -72,6 +72,30 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 			 return duplicate;
 		},
 
+		/**
+		 * Retrieves the option element with a selected designation iDonateEmbedLoad
+		 * 
+		 * @param {jQuery} $select The jQuery object that contains option elements (usually a select dropdown)
+		 * @param {string} designationId The designation ID of the element you want to find
+		 * 
+		 * @returns {jQuery} The jQuery object if the option element is found or null if not found
+		 */
+		findElementbyDesignation: function ($select, designationId)
+		{
+			var $element = null;
+			
+			$select.find("option").each(function()
+			{
+				if(designationId === jQuery(this).attr("value"))
+				{ 
+					$element = jQuery(this);
+					return false; //break out of the each loop
+				}
+			});
+
+			 return $element;
+		},
+
 		validateAmount: function (intendedAmount)
 		{
 			var validMoneyAmount = false;

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -214,11 +214,22 @@ jQuery(document).ready(function($) {
 		}
 	});
 
-	loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities");
-	loadPriorities($("#unit-priorities"), wpData.unit_taxonomy, wpData.unit_category)
-	.done(function() {
-		loadFundFromDesignationID($("#unit-priorities"), wpData.unit_designation);
-	});
+	// if a unit is specified
+	if(wpData.unit_taxonomy && wpData.unit_category)
+	{
+		loadPriorities($("#unit-priorities"), wpData.unit_taxonomy, wpData.unit_category)
+		.done(function() {
+			loadFundFromDesignationID($("#unit-priorities"), wpData.unit_designation);
+		});
+		loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities");
+	}
+	else
+	{
+		loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities")
+		.done(function() {
+			loadFundFromDesignationID($("#priorities"), wpData.unit_designation);
+		});
+	}
 });
 
 function loadFundFromDesignationID($list, designationId){
@@ -247,7 +258,7 @@ function loadFundFromDesignationID($list, designationId){
 					var $fund = jQuery('<option>', { value : json[0]["designation_id"] })
 								.text( wsuwpUtils.htmlDecode(json[0]["fund_name"]) );
 					$list.append($fund);
-					
+
 					// Select and show amount buttons
 					wsuwpUtils.selectFundInDropdown($fund, designationId); 
 				}
@@ -280,7 +291,7 @@ function loadPriorities($list, category, subcategory)
 	}
 
 	//return an already resolved promise (http://stackoverflow.com/a/33656679)
-	return $.when();
+	return jQuery.when();
 }
 
 function addFundAction(scholarship)

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -232,7 +232,7 @@ function loadPriorities($list, category, subcategory)
 			$list.append('<option disabled selected value> SELECT A FUND </option>');
 			jQuery.each(json, function(key, value) {   
 				$list
-				.append(jQuery('<option>', { value : value["designationId"] })
+				.append(jQuery('<option>', { value : value["designation_id"] })
 				.text( wsuwpUtils.htmlDecode(value["fund_name"]) ) ); 
 			});
 

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -217,8 +217,30 @@ jQuery(document).ready(function($) {
 
 
 	loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities");
-	loadPriorities($("#unit-priorities"), wpData.unit_taxonomy, wpData.unit_category);
+	loadPriorities($("#unit-priorities"), wpData.unit_taxonomy, wpData.unit_category)
+	.done(function() {
+		loadFundFromDesignationID($("#unit-priorities"), "d3f34029-cf8c-4051-a5f4-fefbdfeb49d5");
+	});
 });
+
+function loadFundFromDesignationID($list, designationId){
+	
+	var $des = wsuwpUtils.findElementbyDesignation($list, designationId);
+
+	// Check if the designation already exists in the priorities list and select item
+	if($des)
+	{
+		$des.prop("selected", true);
+		var fundName = $des.text();
+		jQuery("#inpDesignationId").text(designationId);
+		jQuery("#inpFundName").text(fundName);
+		showAmountZone();
+	}
+	else // Otherwise add it to the priorities list and select it
+	{
+
+	}
+}
 
 function loadPriorities($list, category, subcategory)
 {
@@ -226,8 +248,8 @@ function loadPriorities($list, category, subcategory)
 		// GET /wp-json/idonate_fundselector/v1/funds/category/subcategory (e.g. GET /wp-json/idonate_fundselector/v1/funds/idonate_priorities/idonate_priorities)
 		var restQueryUrl = wpData.plugin_url_base + 'funds/' + category + '/' + subcategory;
 		
-		jQuery.getJSON( restQueryUrl )
-		.done(function( json ) { 
+		return jQuery.getJSON( restQueryUrl )
+		.then(function( json ) { 
 			$list.empty();
 			$list.append('<option disabled selected value> SELECT A FUND </option>');
 			jQuery.each(json, function(key, value) {   
@@ -242,6 +264,9 @@ function loadPriorities($list, category, subcategory)
 			}
 		})
 	}
+
+	//return an already resolved promise (http://stackoverflow.com/a/33656679)
+	return $.when();
 }
 
 function addFundAction(scholarship)

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -214,8 +214,6 @@ jQuery(document).ready(function($) {
 		}
 	});
 
-
-
 	loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities");
 	loadPriorities($("#unit-priorities"), wpData.unit_taxonomy, wpData.unit_category)
 	.done(function() {
@@ -225,20 +223,36 @@ jQuery(document).ready(function($) {
 
 function loadFundFromDesignationID($list, designationId){
 	
-	var $des = wsuwpUtils.findElementbyDesignation($list, designationId);
-
-	// Check if the designation already exists in the priorities list and select item
-	if($des)
+	if(designationId)
 	{
-		$des.prop("selected", true);
-		var fundName = $des.text();
-		jQuery("#inpDesignationId").text(designationId);
-		jQuery("#inpFundName").text(fundName);
-		showAmountZone();
-	}
-	else // Otherwise add it to the priorities list and select it
-	{
+		var $des = wsuwpUtils.findElementbyDesignation($list, designationId);
 
+		// Check if the designation already exists in the priorities list and select item
+		if($des)
+		{
+			// Select and show amount buttons
+			wsuwpUtils.selectFundInDropdown($des, designationId);
+		}
+		else // Otherwise add it to the priorities list and select it
+		{
+			// Look up the Fund Name by Designation ID
+			// GET /wp-json/idonate_fundselector/v1/fund/designationId (e.g. GET /wp-json/idonate_fundselector/v1/fund/12dc5acc-07ea-4ed3-9c92-4b9ebe7c951c)
+			var restQueryUrl = wpData.plugin_url_base + 'fund/' + designationId;
+			
+			jQuery.getJSON( restQueryUrl )
+			.then(function( json ) { 			
+				if(json.length > 0)
+				{
+					// Add to priorities
+					var $fund = jQuery('<option>', { value : json[0]["designation_id"] })
+								.text( wsuwpUtils.htmlDecode(json[0]["fund_name"]) );
+					$list.append($fund);
+					
+					// Select and show amount buttons
+					wsuwpUtils.selectFundInDropdown($fund, designationId); 
+				}
+			})
+		}
 	}
 }
 

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -219,7 +219,7 @@ jQuery(document).ready(function($) {
 	loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities");
 	loadPriorities($("#unit-priorities"), wpData.unit_taxonomy, wpData.unit_category)
 	.done(function() {
-		loadFundFromDesignationID($("#unit-priorities"), "d3f34029-cf8c-4051-a5f4-fefbdfeb49d5");
+		loadFundFromDesignationID($("#unit-priorities"), wpData.unit_designation);
 	});
 });
 


### PR DESCRIPTION
Several units use a query parameter to directly link to a fund from their website. This feature adds that ability to the plugin, as request in Issue #96.

For the plugin, if a designation ID is given as a parameter, the correct fund is pre-selected and the amount selection options are shown. The fund is selected if in the current priorities list or added, then selected if it is not in the list.

I added a new REST API endpoint to get a fund name by designation ID and I moved the REST API methods to their own PHP file for easier maintainability.