### PR TITLE
Use different phpunit versions depending on PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ matrix:
 
 before_script:
     - |
-      if [[ ! -z "$WP_VERSION" ]] ; then
-        bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-      fi
-    - |
       if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
         composer global require "phpunit/phpunit=5.7.*"
       else
         composer global require "phpunit/phpunit=4.8.*"
+      fi
+    - |
+      if [[ ! -z "$WP_VERSION" ]] ; then
+        bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
       fi
     - |
       if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
@@ -41,6 +41,10 @@ before_script:
         npm install
         composer install
       fi
+    - phpunit --version
+    - node --version
+    - npm --version
+    - composer --version
 
 script:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ before_script:
         bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
       fi
     - |
+      if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
+        composer global require "phpunit/phpunit=5.7.*"
+      else
+        composer global require "phpunit/phpunit=4.8.*"
+      fi
+    - |
       if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
         rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 6
         npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ branches:
 matrix:
   include:
     - php: 5.6
-      env: WP_VERSION=latest WP_MULTISITE=1
+      env: WP_VERSION=latest WP_MULTISITE=1 WP_TRAVISCI=travis:phpunit
     - php: 7.0
-      env: WP_VERSION=latest WP_MULTISITE=1
+      env: WP_VERSION=latest WP_MULTISITE=1 WP_TRAVISCI=travis:phpunit
     - php: 5.6
       env: WP_TRAVISCI=phpcs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,38 @@ matrix:
 
 before_script:
     - |
-      if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-        composer global require "phpunit/phpunit=5.7.*"
-      else
-        composer global require "phpunit/phpunit=4.8.*"
+      # Remove Xdebug for a huge performance increase, but not from nightly or hhvm:
+      stable='^[0-9\.]+$'
+      if [[ "$TRAVIS_PHP_VERSION" =~ $stable ]]; then
+        phpenv config-rm xdebug.ini
+      fi
+    - |
+      # Export Composer's global bin dir to PATH, but not on PHP 5.2:
+      if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
+        composer config --list --global
+        export PATH=`composer config --list --global | grep '\[home\]' | { read a; echo "${a#* }/vendor/bin:$PATH"; }`
+      fi
+    - |
+      # Install the specified version of PHPUnit depending on the PHP version:
+      if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
+        case "$TRAVIS_PHP_VERSION" in
+          7.1|7.0|hhvm|nightly)
+            echo "Using PHPUnit 5.7"
+            composer global require "phpunit/phpunit=5.7.*"
+            ;;
+          5.6|5.5|5.4|5.3)
+            echo "Using PHPUnit 4.8"
+            composer global require "phpunit/phpunit=4.8.*"
+            ;;
+          5.2)
+            # Do nothing, use default PHPUnit 3.6.x
+            echo "Using default PHPUnit, hopefully 3.6"
+            ;;
+          *)
+            echo "No PHPUnit version handling for PHP version $TRAVIS_PHP_VERSION"
+            exit 1
+            ;;
+        esac
       fi
     - |
       if [[ ! -z "$WP_VERSION" ]] ; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -79,6 +79,7 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	cd $WP_TESTS_DIR


### PR DESCRIPTION
Travis CI made a change in the phpunit version that is provided for PHP 7.x in the VM build by default. This looks for PHP 7 and requires the appropriate phpunit version for WP tests.