### PR TITLE
Calculate Add Fund Indicator animation based on number of tabs.

### DIFF
--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -45,9 +45,12 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 				
 				jQuery(".help-text-caret").delay(1200);
 				
-				for(var i = 0; i < jQuery("#majorcategory a").length - 1; i++)
+				var numCategories = jQuery("#majorcategory a").length;
+				var movementPercentage = numCategories ? 100 / numCategories: 0;
+				
+				for(var i = 0; i < numCategories - 1; i++)
 				{
-					jQuery(".help-text-caret").animate({marginLeft: "+=20%"}, {duration: 500}).delay(500);
+					jQuery(".help-text-caret").animate({marginLeft: "+=" + movementPercentage + "%"}, {duration: 500}).delay(500);
 				}
 				jQuery(".help-text-caret").animate({marginLeft: origMargin}, {duration: 500});
 			}


### PR DESCRIPTION
The moving arrow for the Add Fund Indicator used the same percentage regardless of the number of tabs (categories) to animate, but varied the actual number of movements with the number of tabs. This led to the arrow moving off of the actual box when it showed the additional unit priorities category.

This fix for issue #104 now calculates the movement percentage based on the number of tabs, so that it stays consistent and within the boundaries of the plugin.

![wsuf fundselector plugintest 012](https://cloud.githubusercontent.com/assets/11821485/23874486/012b2d2c-07f3-11e7-9865-75126222c935.gif)
