### PR TITLE
Select the actual parent since element changed.

### DIFF
--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -148,7 +148,7 @@ jQuery(document).ready(function($) {
 	$('body').on('click', '#selectedFunds li span.close a', function (event) {
 		event.preventDefault();
 		
-		$parent = $(this).parent().parent()
+		$parent = $(this).parent().parent().parent();
 
 		if($parent.hasClass("fund-scholarship")) $("#genScholarship").prop("checked", false);
 


### PR DESCRIPTION
The Fund List element structure changed when I moved the error messages, so the Remove Fund option was no longer getting the correct parent. This was causing issues when attempting to remove a fund.

This PR makes sure the parent is getting correctly assigned, so the proper element is removed, not just a child.