### PR TITLE
Reset form elements when switching tabs.

### DIFF
--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -37,6 +37,8 @@ jQuery(document).ready(function($) {
 	// Major Category Click Events
 	$("#majorcategory a")
 	.click( function( event ) {
+		resetForm(true);
+		
 		$("#majorcategory a").removeClass("active");  
 		$(".categoryTab").addClass('hidden');
 
@@ -320,14 +322,27 @@ function addFundAction(scholarship)
 	}
 }
 
-function resetForm()
+/**
+ * Resets the plugin elements back to their default states
+ * 
+ * @param {boolean} immediate If true, certain elements hide right away instead of fading out (like on tab switch)
+ */
+function resetForm(immediate)
 {
 	jQuery("#fundSearch").val("");
 	jQuery('.fund-selection').prop('selectedIndex', 0);
 	jQuery('.category-selection').prop('selectedIndex', 0);
 	setTimeout(function(){ jQuery('.amountwrapper .selected').removeClass('selected'); }, 1300);
-	hideAmountZone();
-	hideother();
+	if(immediate) { 		
+		jQuery(".amountwrapper.wrapper").hide();
+		jQuery(".otherprice").hide();
+		jQuery("#errorOtherAmount").hide();	 
+	}
+	else
+	{
+		hideAmountZone();
+		hideOther();
+	}
 }
 
 function handleAmountSelectionClick(event)
@@ -442,10 +457,10 @@ function showOther()
 	showAnything(jQuery("#errorOtherAmount")); 
 }
 
-function hideother()
+function hideOther()
 {
 	hideAnything( jQuery(".otherprice") );
-	hideAnything(jQuery("#errorOtherAmount"));
+	hideAnything( jQuery("#errorOtherAmount") );
 }
 
 function showAnything(element)


### PR DESCRIPTION
If you selected a fund, but not a dollar amount, then switch to a different category (tab), the dollar amount selection would still stay visible. Since we already reset the subcategory and fund indicators, these should be hidden and reset too, as noted in Issue #118.

This update inlcudes the following changes:
* Reset form elements when switching tabs.
* Add an immediate flag for quick hiding instead of fades. 
  * This is more consistent with the tab switch experience.
* Fixed a method name and added some JSDoc comments