### PR TITLE
Donor pays fee checkbox - Issue #120

### DIFF
--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -214,6 +214,7 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 			';
 		}
 
+		// Advancement Fee Checkbox
 		if ( ! empty( $args['adv_fee_designation_id'] ) ) {
 			$return_string .= '
 			<div class="additional-info" style="display:none;">
@@ -224,6 +225,11 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 			</div>
 			';
 		}
+
+		// Total Amount information
+		$return_string .= '
+		<div class="disclaimer total" style="display:none;"><span class="first-sentence">Your generous donation will total $<span id="totalAmount"></span> today.</span> When you proceed to checkout, you will be sent to our payment processing service.</div>
+		';
 
 		// Gift Planning Checkboxes
 		$return_string .= '
@@ -243,11 +249,6 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 				</label>
 			</span>
 		</div>
-		';
-
-		// Total Amount information
-		$return_string .= '
-		<div class="disclaimer total" style="display:none;"><span class="first-sentence">Your generous donation will total $<span id="totalAmount"></span> today.</span> When you proceed to checkout, you will be sent to our payment processing service.</div>
 		';
 
 		// Continue button

--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -37,6 +37,9 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 			'unit_description' => '',
 			'unit_title' => '',
 			'unit_scholarship_category' => 'idonate_general-scholarship',
+			'adv_fee_message' => '',
+			'adv_fee_designation_id' => '',
+			'adv_fee_percentage' => '5',
 		), $atts );
 
 		$args['embed'] = sanitize_key( $args['embed'] );
@@ -51,6 +54,10 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 		$args['unit_title'] = sanitize_text_field( $args['unit_title'] );
 		$args['unit_description'] = esc_html( $args['unit_description'] );
 
+		$args['adv_fee_message'] = esc_html( $args['adv_fee_message'] );
+		$args['adv_fee_designation_id'] = sanitize_key( $args['adv_fee_designation_id'] );
+		$args['adv_fee_percentage'] = sanitize_key( $args['adv_fee_percentage'] );
+
 		$des_id_query_param = ! empty( $_GET['fund'] ) ? sanitize_key( $_GET['fund'] ) : null;
 
 		wp_localize_script( 'wsuf_fundselector', 'wpData', array(
@@ -59,6 +66,8 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 			'unit_taxonomy' => $args['unit_taxonomy'],
 			'unit_category' => $args['unit_category'],
 			'unit_designation' => $des_id_query_param,
+			'adv_fee_message' => $args['adv_fee_message'],
+			'adv_fee_percentage' => $args['adv_fee_percentage'],
 		));
 
 		$return_string = '<div id="fundSelectionForm"><div id="firstform">';
@@ -205,6 +214,18 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 			';
 		}
 
+		if ( ! empty( $args['adv_fee_designation_id'] ) ) {
+			$return_string .= '
+			<div class="additional-info" style="display:none;">
+				<span>
+					<input type="checkbox" id="advFeeCheck" data-designation_id="' . $args['adv_fee_designation_id'] . '" data-amount=10 > 
+					<label for="advFeeCheck"><span id="advFeeAmount"></span></label>
+				</span>
+			</div>
+			';
+		}
+
+		// Gift Planning Checkboxes
 		$return_string .= '
 		<div class="additional-info gift-planning" style="display:none;">
 			<div class="additional-info-header">Is WSU in your Will?</div>

--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -39,7 +39,7 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 			'unit_scholarship_category' => 'idonate_general-scholarship',
 			'adv_fee_message' => '',
 			'adv_fee_designation_id' => '',
-			'adv_fee_percentage' => '5',
+			'adv_fee_percentage' => '',
 		), $atts );
 
 		$args['embed'] = sanitize_key( $args['embed'] );

--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -205,6 +205,12 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 			{
 				var advFeeDecimal = donationTotal * (advFee * 0.01);
 				if(addAdvFee) donationTotal = donationTotal + advFeeDecimal;
+				
+				// Use Mustache / Handlebars syntax for templating
+				_.templateSettings = {
+					interpolate: /\{\{(.+?)\}\}/g
+				};
+				
 				jQuery("#advFeeAmount").text(_.template(wpData.adv_fee_message)({advFeeAmount: advFeeDecimal.toFixed(2) }));
 				jQuery("#advFeeCheck").attr("data-amount", advFeeDecimal);
 			}

--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -42,7 +42,7 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 						e.target.parent().parent().attr("data-amount", e.value);
 						jQuery("#error" + designationId).text("");
 
-						wsuwpUtils.updateTotalAmountText();
+						wsuwpUtils.updateTotalAmountText(jQuery("#advFeeCheck").prop('checked'));
 					}
 				});
 			}
@@ -196,14 +196,20 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 			return sum;
 		},
 
-		updateTotalAmountText: function(addAdvFee, advFee)
+		/**
+		 * Updates the Total Amount text and the Advancement fee text whenever the values change
+		 * 
+		 * @param {bool} If true, the Advancement fee should be added to the donation total
+		 * 
+		 */
+		updateTotalAmountText: function(addAdvFee)
 		{
 			var designations = wsuwpUtils.getDesignationList(jQuery("#selectedFunds"));
 			var donationTotal = wsuwpUtils.getDonationTotal(designations);
 			
 			if(wpData.adv_fee_percentage)
 			{
-				var advFeeDecimal = donationTotal * (advFee * 0.01);
+				var advFeeDecimal = donationTotal * (wpData.adv_fee_percentage * 0.01);
 				if(addAdvFee) donationTotal = donationTotal + advFeeDecimal;
 				
 				// Use Mustache / Handlebars syntax for templating

--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -196,11 +196,21 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 			return sum;
 		},
 
-		updateTotalAmountText: function()
+		updateTotalAmountText: function(addAdvFee, advFee)
 		{
 			var designations = wsuwpUtils.getDesignationList(jQuery("#selectedFunds"));
-			jQuery("#totalAmount").text(wsuwpUtils.getDonationTotal(designations).toFixed(2));
-		},
+			var donationTotal = wsuwpUtils.getDonationTotal(designations);
+			
+			if(wpData.adv_fee_percentage)
+			{
+				var advFeeDecimal = donationTotal * (advFee * 0.01);
+				if(addAdvFee) donationTotal = donationTotal + advFeeDecimal;
+				jQuery("#advFeeAmount").text(_.template(wpData.adv_fee_message)({advFeeAmount: advFeeDecimal.toFixed(2) }));
+			}
+
+			jQuery("#totalAmount").text(donationTotal.toFixed(2));
+			
+		},	
 
 		/**
 		 * Selects a fund in a dropdown select list and shows the amount zone

--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -206,6 +206,7 @@ window.wsuwpUtils = window.wsuwpUtils || {};
 				var advFeeDecimal = donationTotal * (advFee * 0.01);
 				if(addAdvFee) donationTotal = donationTotal + advFeeDecimal;
 				jQuery("#advFeeAmount").text(_.template(wpData.adv_fee_message)({advFeeAmount: advFeeDecimal.toFixed(2) }));
+				jQuery("#advFeeCheck").attr("data-amount", advFeeDecimal);
 			}
 
 			jQuery("#totalAmount").text(donationTotal.toFixed(2));

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -154,7 +154,7 @@ jQuery(document).ready(function($) {
 
 		$parent.fadeOut(1000, function(){ 
             $(this).remove();
-            wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'), wpData.adv_fee_percentage);
+            wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'));
         });
 
         // If the Fund list is empty, disable the Continue Button
@@ -213,7 +213,7 @@ jQuery(document).ready(function($) {
 			// the checkbox is now no longer checked
 			$("#selectedFunds > li.fund-scholarship").remove();
 
-			wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'), wpData.adv_fee_percentage);
+			wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'));
 
 			// If the Fund list is empty, disable the Continue Button
 			if ($("#selectedFunds").find("li").length === 0) {
@@ -225,7 +225,7 @@ jQuery(document).ready(function($) {
 
 	$("#advFeeCheck").change(function() {
 		// this will contain a reference to the checkbox
-		wsuwpUtils.updateTotalAmountText(this.checked, wpData.adv_fee_percentage);
+		wsuwpUtils.updateTotalAmountText(this.checked);
 	});
 
 	// if a unit is specified
@@ -318,7 +318,7 @@ function addFundAction(scholarship)
 		wsuwpUtils.addListItem(jQuery("#selectedFunds"), fundName, designationId, jQuery("#inpAmount").val(), scholarship);
 		wsuwpUtils.enableButton(jQuery("#continueButton"));
 		
-		wsuwpUtils.updateTotalAmountText(jQuery("#advFeeCheck").prop('checked'), wpData.adv_fee_percentage);
+		wsuwpUtils.updateTotalAmountText(jQuery("#advFeeCheck").prop('checked'));
 		showAnything(jQuery(".disclaimer"));
 		showContinueButton();
 		resetForm();

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -154,7 +154,7 @@ jQuery(document).ready(function($) {
 
 		$parent.fadeOut(1000, function(){ 
             $(this).remove();
-            wsuwpUtils.updateTotalAmountText();
+            wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'), 5);
         });
 
         // If the Fund list is empty, disable the Continue Button
@@ -213,7 +213,7 @@ jQuery(document).ready(function($) {
 			// the checkbox is now no longer checked
 			$("#selectedFunds > li.fund-scholarship").remove();
 
-			wsuwpUtils.updateTotalAmountText();
+			wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'), 5);
 
 			// If the Fund list is empty, disable the Continue Button
 			if ($("#selectedFunds").find("li").length === 0) {
@@ -221,6 +221,11 @@ jQuery(document).ready(function($) {
 				hideContinueButton();
 			}
 		}
+	});
+
+	$("#advFeeCheck").change(function() {
+		// this will contain a reference to the checkbox
+		wsuwpUtils.updateTotalAmountText(this.checked, 5);
 	});
 
 	// if a unit is specified
@@ -313,7 +318,7 @@ function addFundAction(scholarship)
 		wsuwpUtils.addListItem(jQuery("#selectedFunds"), fundName, designationId, jQuery("#inpAmount").val(), scholarship);
 		wsuwpUtils.enableButton(jQuery("#continueButton"));
 		
-		wsuwpUtils.updateTotalAmountText();
+		wsuwpUtils.updateTotalAmountText(jQuery("#advFeeCheck").prop('checked'), 5);
 		showAnything(jQuery(".disclaimer"));
 		showContinueButton();
 		resetForm();

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -154,7 +154,7 @@ jQuery(document).ready(function($) {
 
 		$parent.fadeOut(1000, function(){ 
             $(this).remove();
-            wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'), 5);
+            wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'), wpData.adv_fee_percentage);
         });
 
         // If the Fund list is empty, disable the Continue Button
@@ -213,7 +213,7 @@ jQuery(document).ready(function($) {
 			// the checkbox is now no longer checked
 			$("#selectedFunds > li.fund-scholarship").remove();
 
-			wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'), 5);
+			wsuwpUtils.updateTotalAmountText($("#advFeeCheck").prop('checked'), wpData.adv_fee_percentage);
 
 			// If the Fund list is empty, disable the Continue Button
 			if ($("#selectedFunds").find("li").length === 0) {
@@ -225,7 +225,7 @@ jQuery(document).ready(function($) {
 
 	$("#advFeeCheck").change(function() {
 		// this will contain a reference to the checkbox
-		wsuwpUtils.updateTotalAmountText(this.checked, 5);
+		wsuwpUtils.updateTotalAmountText(this.checked, wpData.adv_fee_percentage);
 	});
 
 	// if a unit is specified
@@ -318,7 +318,7 @@ function addFundAction(scholarship)
 		wsuwpUtils.addListItem(jQuery("#selectedFunds"), fundName, designationId, jQuery("#inpAmount").val(), scholarship);
 		wsuwpUtils.enableButton(jQuery("#continueButton"));
 		
-		wsuwpUtils.updateTotalAmountText(jQuery("#advFeeCheck").prop('checked'), 5);
+		wsuwpUtils.updateTotalAmountText(jQuery("#advFeeCheck").prop('checked'), wpData.adv_fee_percentage);
 		showAnything(jQuery(".disclaimer"));
 		showContinueButton();
 		resetForm();

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -355,6 +355,12 @@ function continueAction()
 	{
 		hideForm();
 
+		var $advFeeCheck = jQuery("#advFeeCheck");
+		
+		if($advFeeCheck.prop("checked")) {
+			designations.push({id: $advFeeCheck.attr("data-designation_id"), amount: parseInt($advFeeCheck.attr("data-amount")) });
+		}
+
 		if(designations.length === 1)
 		{
 			var des = designations[0];


### PR DESCRIPTION
If a fee is assessed, we want to give the donor the option to include that fee in their gift, so the whole of the intended gifts goes toward their chosen fund.

1. This update adds a checkbox for that option as noted in #120. 
    * The checkbox will only be shown if a designation is configured on the shortcode for it. 
    * The fee percentage and checkbox description can also be set on the shortcode.

2. The checkbox description will update with the fee amount dynamically. 
    * If it is checked, it will also update the gift total.

3. I also moved the Total paragraph up for better visibility, especially on mobile devices.