### PR TITLE
Thank you page - Remove extra spacing from conditionals

### DIFF
--- a/includes/class-wsuwp-shortcode-thankyoupage.php
+++ b/includes/class-wsuwp-shortcode-thankyoupage.php
@@ -155,6 +155,7 @@ class WSUWP_Plugin_iDonate_ShortCode_ThankYouPage {
 	**/
 	private function replace_conditionals( $content, $query_params ) {
 		$tags = array();
+		// This RegEx captures values inside {{if <value>}}{{end}} blocks (as well as any optional surrounding <p> or ending <br /> tags)
 		preg_match_all( '/(?:\<p\>)?{{if\s+(.*?)}}(.*?){{end}}(?:\<\/p\>|\<br\s*?\/\s*>)?/is', $content, $tags, PREG_SET_ORDER );
 
 		foreach ( $tags as $tag ) {

--- a/includes/class-wsuwp-shortcode-thankyoupage.php
+++ b/includes/class-wsuwp-shortcode-thankyoupage.php
@@ -155,7 +155,7 @@ class WSUWP_Plugin_iDonate_ShortCode_ThankYouPage {
 	**/
 	private function replace_conditionals( $content, $query_params ) {
 		$tags = array();
-		preg_match_all( '/{{if\s+(.*?)}}(.*?){{end}}/is', $content, $tags, PREG_SET_ORDER );
+		preg_match_all( '/(?:\<p\>)?{{if\s+(.*?)}}(.*?){{end}}(?:\<\/p\>|\<br\s*?\/\s*>)?/is', $content, $tags, PREG_SET_ORDER );
 
 		foreach ( $tags as $tag ) {
 			$replace_content = ! empty( $query_params[ $tag[1] ] ) ? $tag[2]: '';


### PR DESCRIPTION
Wordpress automatically adds paragraph tags and line breaks around text entered via the post editor. These extra tags were causing whitespace to show on the Thank You page even if the space wasn't supposed to be there. 

The Thank You page uses ```{{if <value>}}<html>{{end}}``` template tags to show HTML in between them only if the value exists and isn't empty. If it is empty, it should just be gone, but WordPress was adding spacing there, so there were unwanted gaps.

This changes captures the ```<p>``` and ```<br>``` tags surrounding the ```{{if <value>}}<html>{{end}}``` template tags, so they are overwritten if the value is empty, but preserved if the value has content.