### PR TITLE
iDonate JSON parsing error

### DIFF
--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -437,8 +437,9 @@ function continueAction(event)
 		}
 
 		var referenceCode = { donorPaysFee: $advFeeCheck.prop("checked"), feePercentage: parseInt(wpData.adv_fee_percentage)};
-		
-		jQuery("#iDonateEmbed").attr("data-reference_code", JSON.stringify(referenceCode));
+		var stringifiedRefCode = new RegExp(JSON.stringify(referenceCode));
+
+		jQuery("#iDonateEmbed").attr("data-reference_code", stringifiedRefCode);
 
 		// Initialize the iDonate embed
 		initializeEmbeds();


### PR DESCRIPTION
The error suggests that the cause of the issue was that the reference code wasn't being parsed correctly. This seemed to be caused by the absence of escape characters. The reference code was made to be a regex, which seemed to fix the problem.