### PR TITLE
iDonate Reference Code Escape Characters

### DIFF
--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -437,7 +437,8 @@ function continueAction(event)
 		}
 
 		var referenceCode = { donorPaysFee: $advFeeCheck.prop("checked"), feePercentage: parseInt(wpData.adv_fee_percentage)};
-		var stringifiedRefCode = new RegExp(JSON.stringify(referenceCode));
+		var stringifiedRefCode = '/' + JSON.stringify(referenceCode) + '/';
+		stringifiedRefCode = stringifiedRefCode.replace(/"/g, '\\"');
 
 		jQuery("#iDonateEmbed").attr("data-reference_code", stringifiedRefCode);
 


### PR DESCRIPTION
Adds escape characters to the quotes in the reference code. Otherwise, the web request format turns out to be invalid