### PR TITLE
Direct Links to Areas

### DIFF
--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -48,7 +48,7 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 		}
 
 		$args['unit_taxonomy'] = sanitize_key( $args['unit_taxonomy'] );
-		$args['unit_category'] = sanitize_key( $args['unit_category'] );
+		$args['unit_category'] = ! empty( $_GET['cat'] ) ? sanitize_key( $_GET['cat'] ) : null;
 		$args['unit_scholarship_category'] = sanitize_key( $args['unit_scholarship_category'] );
 		$args['unit_title'] = sanitize_text_field( $args['unit_title'] );
 		$args['unit_description'] = esc_html( $args['unit_description'] );
@@ -57,6 +57,7 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 		$args['adv_fee_percentage'] = sanitize_key( $args['adv_fee_percentage'] );
 
 		$des_id_query_param = ! empty( $_GET['fund'] ) ? sanitize_key( $_GET['fund'] ) : null;
+		$area = ! empty( $_GET['area'] ) ? sanitize_key( $_GET['area'] ) : null;
 
 		wp_localize_script( 'wsuf_fundselector', 'wpData', array(
 			'request_url_base' => esc_url( $args['rest_url'] . 'wp/v2/' ),
@@ -64,6 +65,7 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 			'unit_taxonomy' => $args['unit_taxonomy'],
 			'unit_category' => $args['unit_category'],
 			'unit_designation' => $des_id_query_param,
+			'area' => $area,
 			'adv_fee_message' => $args['adv_fee_message'],
 			'adv_fee_percentage' => $args['adv_fee_percentage'],
 		));

--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -48,7 +48,7 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 		}
 
 		$args['unit_taxonomy'] = sanitize_key( $args['unit_taxonomy'] );
-		$args['unit_category'] = ! empty( $_GET['cat'] ) ? sanitize_key( $_GET['cat'] ) : null;
+		$args['unit_category'] = sanitize_key( $args['unit_category'] );
 		$args['unit_scholarship_category'] = sanitize_key( $args['unit_scholarship_category'] );
 		$args['unit_title'] = sanitize_text_field( $args['unit_title'] );
 		$args['unit_description'] = esc_html( $args['unit_description'] );
@@ -58,6 +58,7 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 
 		$des_id_query_param = ! empty( $_GET['fund'] ) ? sanitize_key( $_GET['fund'] ) : null;
 		$area = ! empty( $_GET['area'] ) ? sanitize_key( $_GET['area'] ) : null;
+		$cat = ! empty( $_GET['cat'] ) ? sanitize_key( $_GET['cat'] ) : null;
 
 		wp_localize_script( 'wsuf_fundselector', 'wpData', array(
 			'request_url_base' => esc_url( $args['rest_url'] . 'wp/v2/' ),
@@ -66,6 +67,7 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 			'unit_category' => $args['unit_category'],
 			'unit_designation' => $des_id_query_param,
 			'area' => $area,
+			'cat' => $cat,
 			'adv_fee_message' => $args['adv_fee_message'],
 			'adv_fee_percentage' => $args['adv_fee_percentage'],
 		));

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -36,7 +36,7 @@ jQuery(document).ready(function($) {
 
 	// Major Category Click Events
 	$("#majorcategory a")
-	.click( function( event ) {
+	.click( function( event, deferred ) {
 		resetForm(true);
 		
 		$("#majorcategory a").removeClass("active");  
@@ -67,12 +67,16 @@ jQuery(document).ready(function($) {
 
 				$.each(json, function(key, value) {   
 					$list
-					.append($('<option>', { value : value["id"], "data-category" : value["taxonomy"] })
+					.append($('<option>', { value : value["id"], "data-category" : value["taxonomy"], "data-subcategory" : value["slug"] })
 					.text( wsuwpUtils.htmlDecode( value["name"]) )); 
 				});
 				$list.prop('disabled', false);
 				$list.addClass('fund');
-				$list.removeClass('loading'); 
+				$list.removeClass('loading');
+
+				if(deferred !== undefined) { //complete deferred function that was passed into the click event
+					deferred.resolve();
+				} 
 			})
 		}
 
@@ -267,10 +271,17 @@ jQuery(document).ready(function($) {
 		loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities");
 	}
 	else if (wpData.area && wpData.unit_category) {
-		
-		var tab = $('#majorcategory').find("[data-category='" + wpData.unit_category + "']");
-		tab.click();
-		tab.addClass("active")
+		//Switch to the correct tab
+		var category = $('#majorcategory').find("[data-category='" + wpData.unit_category + "']");
+		var defer = $.Deferred();
+		category.trigger('click', defer);
+		category.addClass("active");
+
+		//Populate the subcategory after the tab has been loaded
+		$.when(defer).done(function () {
+		var subcategory = $('#subcategories').find("[data-subcategory='" + wpData.area + "']");
+		subcategory.prop("selected", true);
+		});
 	}
 	else
 	{

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -279,8 +279,9 @@ jQuery(document).ready(function($) {
 
 		//Populate the subcategory after the tab has been loaded
 		$.when(defer).done(function () {
-		var subcategory = $('#subcategories').find("[data-subcategory='" + wpData.area + "']");
-		subcategory.prop("selected", true);
+			var subcategory = $('#subcategories').find("[data-subcategory='" + wpData.area + "']");
+			subcategory.prop("selected", true);
+			subcategory.trigger('change');
 		});
 	}
 	else

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -270,9 +270,9 @@ jQuery(document).ready(function($) {
 		});
 		loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities");
 	}
-	else if (wpData.area && wpData.unit_category) {
+	else if (wpData.area && wpData.cat) {
 		//Switch to the correct tab
-		var category = $('#majorcategory').find("[data-category='" + wpData.unit_category + "']");
+		var category = $('#majorcategory').find("[data-category='" + wpData.cat + "']");
 		var defer = $.Deferred();
 		category.trigger('click', defer);
 		category.addClass("active");

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -286,7 +286,7 @@ jQuery(document).ready(function($) {
 	}
 	else
 	{
-		loadPriorities($("#priorities"), "idonate_priorities", wpData.unit_category)
+		loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities")
 		.done(function() {
 			loadFundFromDesignationID($("#priorities"), wpData.unit_designation);
 		});

--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -266,9 +266,15 @@ jQuery(document).ready(function($) {
 		});
 		loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities");
 	}
+	else if (wpData.area && wpData.unit_category) {
+		
+		var tab = $('#majorcategory').find("[data-category='" + wpData.unit_category + "']");
+		tab.click();
+		tab.addClass("active")
+	}
 	else
 	{
-		loadPriorities($("#priorities"), "idonate_priorities", "idonate_priorities")
+		loadPriorities($("#priorities"), "idonate_priorities", wpData.unit_category)
 		.done(function() {
 			loadFundFromDesignationID($("#priorities"), wpData.unit_designation);
 		});
@@ -301,7 +307,7 @@ function loadFundFromDesignationID($list, designationId){
 					var $fund = jQuery('<option>', { value : json[0]["designation_id"] })
 								.text( wsuwpUtils.htmlDecode(json[0]["fund_name"]) );
 					$list.append($fund);
-
+					
 					// Select and show amount buttons
 					wsuwpUtils.selectFundInDropdown($fund, designationId); 
 				}


### PR DESCRIPTION
Units will now be able to give out links to their area using the format domain.wsu.edu/?cat=[category_slug]&area=[subcategory_slug]

If the area is incorrect but the category is correct, it will take the user directly to the major category tab but without a subcategory selected. If the category is incorrect the user will be directed to the priorities. This change doesn't populate the funds picker, and doesn't change how direct links to funds work.