### PR TITLE
Focus Category After Load

### DIFF
--- a/includes/wsuwp-shortcode-fundselector.js
+++ b/includes/wsuwp-shortcode-fundselector.js
@@ -48,8 +48,7 @@ jQuery(document).ready(function($) {
 		var categoryName = $(this).attr("data-category");
 
 		if(categoryName) {
-			$('#subcategories').focus();
-
+			
 			var restUrl = wpData.request_url_base + encodeURIComponent(categoryName) + "?per_page=100&orderby=name";
 
 			var $list = $('#subcategories');
@@ -75,6 +74,7 @@ jQuery(document).ready(function($) {
 				$list.prop('disabled', false);
 				$list.addClass('fund');
 				$list.removeClass('loading'); 
+				$('#subcategories').focus(); 
 			})
 		}
 


### PR DESCRIPTION
The focus event was kicking off while the category options were still loading. This worked fine in Firefox, but didn't work in Internet Explorer or Chrome.