### PR TITLE
Add a new Fund Editor role

### DIFF
--- a/includes/class-custom-post-type-fund.php
+++ b/includes/class-custom-post-type-fund.php
@@ -24,7 +24,7 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 
 		add_action( 'init', array( $this, 'custom_post_types' ) );
 		$this->add_idonate_fund_caps_to_admin();
-		$this->add_idonate_fund_caps_to_non_admin_roles();
+		$this->create_fund_editor_role();
 	}
 
 	function custom_post_types() {
@@ -51,7 +51,14 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 		register_post_type( 'idonate_fund', $args );
 	}
 
-	# Give Administrators All Fund Editing Capabilities
+	/**
+	*
+	* Give Administrators all Fund Editing Capabilities
+	*
+	* @link       http://www.nathanfeaver.com/blog/custom_post_types_and_roles_in_wordpress/
+	* @since      1.1.2
+	*
+	*/
 	function add_idonate_fund_caps_to_admin() {
 		$caps = array(
 			'read',
@@ -79,11 +86,18 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 		}
 	}
 
-	# Give other roles Fund editing Capabilities
-	function add_idonate_fund_caps_to_non_admin_roles() {
-		add_role( 'fund_editor', 'Fund Editor' );
+	/**
+	*
+	* Creates a new role called Fund Editor that only has access to create and update Funds.
+	* This role is designed to allow the delegation of fund updates without access to the rest of the WP site.
+	*
+	* @link       http://www.nathanfeaver.com/blog/custom_post_types_and_roles_in_wordpress_2/
+	* @since      1.1.2
+	*
+	*/
+	function create_fund_editor_role() {
 
-		# Everyone gets these capabilities:
+		# Fund Editors only get these capabilities:
 		$caps = array(
 			'read_idonate_fund',
 			'read_private_idonate_funds',
@@ -95,14 +109,6 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 			'delete_idonate_funds',
 		);
 
-		$roles = array(
-			get_role( 'fund_editor' ),
-		);
-
-		foreach ( $roles as $role ) {
-			foreach ( $caps as $cap ) {
-				$role->add_cap( $cap );
-			}
-		}
+		add_role( 'fund_editor', 'Fund Editor', $caps );
 	}
 }

--- a/includes/class-custom-post-type-fund.php
+++ b/includes/class-custom-post-type-fund.php
@@ -24,6 +24,7 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 
 		add_action( 'init', array( $this, 'custom_post_types' ) );
 		$this->add_idonate_fund_caps_to_admin();
+		$this->add_idonate_fund_caps_to_non_admin_roles();
 	}
 
 	function custom_post_types() {
@@ -43,8 +44,8 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 			'hierarchical' => false,
 			'taxonomies' => array( 'idonate_priorities', 'idonate_colleges', 'idonate_campuses', 'idonate_programs' ),
 			'supports' => array( 'title', 'custom-fields' ),
-    		'capability_type' => array( 'idonate_fund' , 'idonate_funds'),
-      		'map_meta_cap' => true,
+			'capability_type' => array( 'idonate_fund' , 'idonate_funds' ),
+			'map_meta_cap' => true,
 		);
 
 		register_post_type( 'idonate_fund', $args );
@@ -69,6 +70,33 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 
 		$roles = array(
 			get_role( 'administrator' ),
+		);
+
+		foreach ( $roles as $role ) {
+			foreach ( $caps as $cap ) {
+				$role->add_cap( $cap );
+			}
+		}
+	}
+
+	# Give other roles Fund editing Capabilities
+	function add_idonate_fund_caps_to_non_admin_roles() {
+		add_role( 'fund_editor', 'Fund Editor' );
+
+		# Everyone gets these capabilities:
+		$caps = array(
+			'read_idonate_fund',
+			'read_private_idonate_funds',
+			'edit_idonate_funds',
+			'edit_private_idonate_funds',
+			'edit_published_idonate_funds',
+			'edit_others_idonate_funds',
+			'publish_idonate_funds',
+			'delete_idonate_funds',
+		);
+
+		$roles = array(
+			get_role( 'fund_editor' ),
 		);
 
 		foreach ( $roles as $role ) {

--- a/includes/class-custom-post-type-fund.php
+++ b/includes/class-custom-post-type-fund.php
@@ -23,7 +23,7 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 	public function init() {
 
 		add_action( 'init', array( $this, 'custom_post_types' ) );
-
+		$this->add_idonate_fund_caps_to_admin();
 	}
 
 	function custom_post_types() {
@@ -48,5 +48,33 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 		);
 
 		register_post_type( 'idonate_fund', $args );
+	}
+
+	# Give Administrators All Fund Editing Capabilities
+	function add_idonate_fund_caps_to_admin() {
+		$caps = array(
+			'read',
+			'read_idonate_fund',
+			'read_private_idonate_funds',
+			'edit_idonate_funds',
+			'edit_private_idonate_funds',
+			'edit_published_idonate_funds',
+			'edit_others_idonate_funds',
+			'publish_idonate_funds',
+			'delete_idonate_funds',
+			'delete_private_idonate_funds',
+			'delete_published_idonate_funds',
+			'delete_others_idonate_funds',
+		);
+
+		$roles = array(
+			get_role( 'administrator' ),
+		);
+
+		foreach ( $roles as $role ) {
+			foreach ( $caps as $cap ) {
+				$role->add_cap( $cap );
+			}
+		}
 	}
 }

--- a/includes/class-custom-post-type-fund.php
+++ b/includes/class-custom-post-type-fund.php
@@ -96,19 +96,20 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 	*
 	*/
 	function create_fund_editor_role() {
+		if ( ! array_key_exists( 'fund_editor', WP_Roles()->get_names() ) ) {
+			# Fund Editors only get these capabilities:
+			$caps = array(
+				'read_idonate_fund',
+				'read_private_idonate_funds',
+				'edit_idonate_funds',
+				'edit_private_idonate_funds',
+				'edit_published_idonate_funds',
+				'edit_others_idonate_funds',
+				'publish_idonate_funds',
+				'delete_idonate_funds',
+			);
 
-		# Fund Editors only get these capabilities:
-		$caps = array(
-			'read_idonate_fund',
-			'read_private_idonate_funds',
-			'edit_idonate_funds',
-			'edit_private_idonate_funds',
-			'edit_published_idonate_funds',
-			'edit_others_idonate_funds',
-			'publish_idonate_funds',
-			'delete_idonate_funds',
-		);
-
-		add_role( 'fund_editor', 'Fund Editor', $caps );
+			add_role( 'fund_editor', 'Fund Editor', $caps );
+		}
 	}
 }

--- a/includes/class-custom-post-type-fund.php
+++ b/includes/class-custom-post-type-fund.php
@@ -43,6 +43,8 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 			'hierarchical' => false,
 			'taxonomies' => array( 'idonate_priorities', 'idonate_colleges', 'idonate_campuses', 'idonate_programs' ),
 			'supports' => array( 'title', 'custom-fields' ),
+    		'capability_type' => array( 'idonate_fund' , 'idonate_funds'),
+      		'map_meta_cap' => true,
 		);
 
 		register_post_type( 'idonate_fund', $args );

--- a/includes/class-custom-taxonomies.php
+++ b/includes/class-custom-taxonomies.php
@@ -107,6 +107,9 @@ class WSUWP_Plugin_iDonate_Custom_Taxonomies {
 			'show_in_rest' => true,
 			'show_ui'           => true,
 			'show_admin_column' => true,
+			'capabilities' => array(
+				'assign_terms' => 'edit_idonate_funds',
+			),
 		);
 
 		register_taxonomy( $name, $post_type, $args );


### PR DESCRIPTION
Add a new role to WordPress as part of the plugin called "Fund Editor" that only has access to create, update and assign priorities (taxonomies) to Funds (`idonate_fund` custom post type). This will be used to delegate the fund changes to non-admins, so they only have access to Funds in WordPress.

The capabilities are added to the custom post type in it's `init()` function. The methods are called directly, as the `init` function is called during the `after_setup_theme` action.

Capabilities are also added to the taxonomies, so they can be assigned to funds by the new Fund Editor role.