### PR TITLE
Add 'read' capability to Fund Editor role

### DIFF
--- a/includes/class-custom-post-type-fund.php
+++ b/includes/class-custom-post-type-fund.php
@@ -25,6 +25,8 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 		add_action( 'init', array( $this, 'custom_post_types' ) );
 		$this->add_idonate_fund_caps_to_admin();
 		$this->create_fund_editor_role();
+		// add fund_editor capabilities, priority must be after the initial role definition
+		add_action( 'init', array( $this, 'update_fund_editor_role' ), 11 );
 	}
 
 	function custom_post_types() {
@@ -99,6 +101,7 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 		if ( ! array_key_exists( 'fund_editor', WP_Roles()->get_names() ) ) {
 			# Fund Editors only get these capabilities:
 			$caps = array(
+				'read',
 				'read_idonate_fund',
 				'read_private_idonate_funds',
 				'edit_idonate_funds',
@@ -111,5 +114,21 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 
 			add_role( 'fund_editor', 'Fund Editor', $caps );
 		}
+	}
+
+	/**
+	*
+	* Add in the missing 'read' capability to existing Fund Editor roles, so they actually see the Funds entry
+	*
+	* @link       https://developer.wordpress.org/plugins/users/roles-and-capabilities/#adding-capabilities
+	* @since      1.1.3
+	*
+	*/
+	function update_fund_editor_role() {
+		// gets the fund_editor role object
+		$role = get_role( 'fund_editor' );
+
+		// add a new capability
+		$role->add_cap( 'read', true );
 	}
 }


### PR DESCRIPTION
Also updates the role if it previously didn't have the capability.
This allows a Fund Editor to see the dashboard and actually open the Funds section.