### PR TITLE
[PR] Explicitly allow each capability in role creation

### DIFF
--- a/includes/class-custom-post-type-fund.php
+++ b/includes/class-custom-post-type-fund.php
@@ -25,8 +25,6 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 		add_action( 'init', array( $this, 'custom_post_types' ) );
 		$this->add_idonate_fund_caps_to_admin();
 		$this->create_fund_editor_role();
-		// add fund_editor capabilities, priority must be after the initial role definition
-		add_action( 'init', array( $this, 'update_fund_editor_role' ), 11 );
 	}
 
 	function custom_post_types() {
@@ -101,34 +99,18 @@ class WSUWP_Plugin_iDonate_Post_Type_Fund {
 		if ( ! array_key_exists( 'fund_editor', WP_Roles()->get_names() ) ) {
 			# Fund Editors only get these capabilities:
 			$caps = array(
-				'read',
-				'read_idonate_fund',
-				'read_private_idonate_funds',
-				'edit_idonate_funds',
-				'edit_private_idonate_funds',
-				'edit_published_idonate_funds',
-				'edit_others_idonate_funds',
-				'publish_idonate_funds',
-				'delete_idonate_funds',
+				'read' => true,
+				'read_idonate_fund' => true,
+				'read_private_idonate_funds' => true,
+				'edit_idonate_funds' => true,
+				'edit_private_idonate_funds' => true,
+				'edit_published_idonate_funds' => true,
+				'edit_others_idonate_funds' => true,
+				'publish_idonate_funds' => true,
+				'delete_idonate_funds' => true,
 			);
 
 			add_role( 'fund_editor', 'Fund Editor', $caps );
 		}
-	}
-
-	/**
-	*
-	* Add in the missing 'read' capability to existing Fund Editor roles, so they actually see the Funds entry
-	*
-	* @link       https://developer.wordpress.org/plugins/users/roles-and-capabilities/#adding-capabilities
-	* @since      1.1.3
-	*
-	*/
-	function update_fund_editor_role() {
-		// gets the fund_editor role object
-		$role = get_role( 'fund_editor' );
-
-		// add a new capability
-		$role->add_cap( 'read', true );
 	}
 }


### PR DESCRIPTION
`add_role()` expects capabilities as `array( 'capability' => true )`. In the WP options table, the `fund_editor` role was stored as:

```
  'fund_editor' =>
  array (
    'name' => 'Fund Editor',
    'capabilities' =>
    array (
      0 => 'read',
      1 => 'read_idonate_fund',
      2 => 'read_private_idonate_funds',
      3 => 'edit_idonate_funds',
      4 => 'edit_private_idonate_funds',
      5 => 'edit_published_idonate_funds',
      6 => 'edit_others_idonate_funds',
      7 => 'publish_idonate_funds',
      8 => 'delete_idonate_funds',
      'read' => true,
    ),
  ),
```

It should be stored as

```
  'fund_editor' =>
  array (
    'name' => 'Fund Editor',
    'capabilities' =>
    array (
      'read' => true,
      'read_idonate_fund' => true,
      'read_private_idonate_funds' => true,
      'edit_idonate_funds' => true,
      'edit_private_idonate_funds' => true,
      'edit_published_idonate_funds' => true,
      'edit_others_idonate_funds' => true,
      'publish_idonate_funds' => true,
      'delete_idonate_funds' => true,
    ),
  ),
```

Once this code change is deployed, I can delete the existing role from the database via WP-CLI. It will then regenerate with the correct capabilities.