### PR TITLE
Issue 201 - Properly Format Currency on Thank You Page

### DIFF
--- a/includes/class-wsuwp-shortcode-thankyoupage.php
+++ b/includes/class-wsuwp-shortcode-thankyoupage.php
@@ -94,6 +94,7 @@ class WSUWP_Plugin_iDonate_ShortCode_ThankYouPage {
 			} elseif ( 'subtype' === $key && 'echeck' === $value ) {
 				$value = 'eCheck';
 			} elseif ( 'value' === $key && $value ) {
+				$value = number_format( $value, 2 );
 				$value = '$' . $value;
 			}
 

--- a/includes/wsuwp-shortcode-fundselector-utils.js
+++ b/includes/wsuwp-shortcode-fundselector-utils.js
@@ -119,7 +119,7 @@ var EPSILON = 0;
 			if(inputAmount && _.isNumber(inputAmount)) {
 				roundedAmount = Math.round(inputAmount * 100 + EPSILON) / 100;
 			}
-			return roundedAmount;
+			return roundedAmount.toFixed(2);
 		},
 
 		 getEpsilon: function() {


### PR DESCRIPTION
The thank you page would display $50 instead if $50.00. To get around the issue, the value is formatted to the hundreths place. Since the front end does the rounding, we shouldn'y have to round any values that are passed from iDonate.