### PR TITLE
Update Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,6 @@ branches:
 matrix:
   include:
     - php: 7.1
-      env: WP_VERSION=nightly
-    - php: 7.0
-      env: WP_VERSION=latest
-    - php: 5.6
       env: WP_TRAVISCI=grunt
 
 before_script:


### PR DESCRIPTION
The Travis build will now only build for the grunt environment with version 7.1 of PHP. This should hopefully help resolve some of our current build issues.