### PR TITLE
Search Ampersand and "and" interchangeably in Fund Search

### DIFF
--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -496,7 +496,13 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 			$post_title = $p->post_title;
 			$post_title = html_entity_decode( $post_title );
 			//do whatever you want with it
-			$return_array[] = array_merge( array( 'designationId' => $des_id, 'name' => $post_title, 'value' => $post_title, 'taxonomy' => $taxonomies ), $post_meta );
+			$merged_array = array_merge( array( 'designationId' => $des_id, 'name' => $post_title, 'value' => $post_title, 'taxonomy' => $taxonomies ), $post_meta );
+			
+			// Only add unique entries
+			if (!in_array($merged_array, $return_array))
+			{
+				$return_array[] = $merged_array;
+			}
 		}
 
 		if ( count( $fund_list ) > 10 ) {

--- a/includes/class-wsuwp-shortcode-fundselector.php
+++ b/includes/class-wsuwp-shortcode-fundselector.php
@@ -452,14 +452,30 @@ class WSUWP_Plugin_iDonate_ShortCode_Fund_Selector {
 	* @since 1.1.7
 	*/
 	function wsuf_fundselector_funds_search_funds( $search_term ) {
-		$fund_list = get_posts(array(
+		$search_term_and = str_ireplace("&", "and", $search_term);
+		
+		$fund_list_and = get_posts(array(
 			'post_type' => 'idonate_fund',
 			'post_status' => 'any',
 			'posts_per_page' => 11,
-			's' => urldecode( $search_term ),
+			's' => urldecode( $search_term_and ),
 			'orderby' => 'title',
 			'order' => 'ASC',
 		));
+		
+		$search_term_amp = str_ireplace("and", "&", $search_term);
+		
+		$fund_list_amp = get_posts(array(
+			'post_type' => 'idonate_fund',
+			'post_status' => 'any',
+			'posts_per_page' => 11,
+			's' => urldecode( $search_term_amp ),
+			'orderby' => 'title',
+			'order' => 'ASC',
+		));
+
+		$fund_list = array_merge( $fund_list_and, $fund_list_amp );
+
 		$fund_list_trimmed = array_slice( $fund_list, 0, 10 );
 		$return_array = array();
 


### PR DESCRIPTION
Allow a donor to search and find a fund even if they used '&' instead of 'and' or vice versa.

Commits
- Search for both & and And in Funds, then combine
- Only add unique entries

Fixes #254 