### PR TITLE
Parse Thank You Page Donor Correctly

### DIFF
--- a/includes/class-wsuwp-shortcode-thankyoupage.php
+++ b/includes/class-wsuwp-shortcode-thankyoupage.php
@@ -117,7 +117,14 @@ class WSUWP_Plugin_iDonate_ShortCode_ThankYouPage {
 		$return_array = array();
 		if ( ! empty( $_GET ) ) {
 
-			$query_params = $this->array_flatten( $_GET );
+			$query_params =  $_GET ;
+			// Parse Donor query param as JSON
+			$query_params["donor"] = json_decode(stripslashes(nl2br($query_params["donor"])), true);
+			
+			$query_params = $this->array_flatten( $query_params );
+			// $query_params["donor_url"] = urldecode($query_params["donor"]);
+			// $query_params["donor_strip"] = stripslashes(nl2br($query_params["donor"]));
+			// $query_params["donor_json"] = json_decode(stripslashes(nl2br($query_params["donor"])), true);
 
 			//loop over each category
 			foreach ( $query_params as $key => $qp ) {

--- a/includes/class-wsuwp-shortcode-thankyoupage.php
+++ b/includes/class-wsuwp-shortcode-thankyoupage.php
@@ -122,9 +122,6 @@ class WSUWP_Plugin_iDonate_ShortCode_ThankYouPage {
 			$query_params["donor"] = json_decode(stripslashes(nl2br($query_params["donor"])), true);
 			
 			$query_params = $this->array_flatten( $query_params );
-			// $query_params["donor_url"] = urldecode($query_params["donor"]);
-			// $query_params["donor_strip"] = stripslashes(nl2br($query_params["donor"]));
-			// $query_params["donor_json"] = json_decode(stripslashes(nl2br($query_params["donor"])), true);
 
 			//loop over each category
 			foreach ( $query_params as $key => $qp ) {


### PR DESCRIPTION
The Donor data in the query string passed to the Thank You page is now in JSON format instead of the previous array format. 
- Updated the Thank You Page shortcode to correctly parse the Donor object now